### PR TITLE
added md link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TILvert
 
-A simple tool to convert TILs from markdown files to HTML
+A simple tool to convert TILs from txt files to HTML.
 
 ## Installation
 
@@ -74,7 +74,7 @@ TILvert is licensed under the [MIT License](https://mit-license.org/)
 
 ## Features
 
-- [x] Convert markdown files to HTML
+- [x] Convert txt files to HTML
 - [x] Replicate directory structure in output directory
 - [x] Non-destructive (Does not delete files in output directory)
 - [x] Customizable HTML page title
@@ -82,6 +82,7 @@ TILvert is licensed under the [MIT License](https://mit-license.org/)
 - [x] Customizable stylesheet
 - [x] Customizable extension for input files
 - [x] Customizable output directory
+- [x] Convert markdown files to HTML (*only supports links currently*)
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TILvert
 
-A simple tool to convert TILs from txt files to HTML.
+A simple tool to convert TILs from txt files to HTML
 
 ## Installation
 
@@ -82,7 +82,7 @@ TILvert is licensed under the [MIT License](https://mit-license.org/)
 - [x] Customizable stylesheet
 - [x] Customizable extension for input files
 - [x] Customizable output directory
-- [x] Convert markdown files to HTML (*only supports links currently*)
+- [x] Convert markdown files to HTML *(only supports links currently)*
 
 ## Examples
 

--- a/dist/package.json
+++ b/dist/package.json
@@ -4,7 +4,7 @@
         "name": "Omar Hussein",
         "url": "https://github.com/omalk98"
     },
-    "version": "0.1.0",
+    "version": "0.1.1",
     "description": "Markdown to HTML CLI converter",
     "main": "./dist/src/main.js",
     "bin": {
@@ -27,6 +27,7 @@
     "devDependencies": {
         "@types/node": "^20.5.9",
         "gh-pages": "^6.0.0",
+        "prettier": "^3.0.3",
         "typescript": "^5.2.2"
     }
 }

--- a/dist/src/utils/process-file.js
+++ b/dist/src/utils/process-file.js
@@ -46,6 +46,22 @@ function processFile(path, title = "", stylesheet, outputPath, extension, meta, 
             }
         });
         segments.forEach((segment) => {
+            if (extension === "md") {
+                const markdownLinkRegex = /\[([^\]]+)\]\(([^\)]+)\)/g;
+                const markdownLinks = segment.match(markdownLinkRegex);
+                if (markdownLinks && markdownLinks.length > 0) {
+                    markdownLinks.forEach((link) => {
+                        const linkGroup = link.match(/\[([^\]]+)\]\(([^\)]+)\)/);
+                        if (linkGroup) {
+                            const anchorTag = index_1.TILvertHTMLDocument.createTag("a", linkGroup[1], {
+                                href: linkGroup[2],
+                                target: "_blank",
+                            });
+                            segment = segment.replace(linkGroup[0], anchorTag);
+                        }
+                    });
+                }
+            }
             htmlDoc.appendToBody(index_1.TILvertHTMLDocument.createTag("p", segment.replace(/\n|\r/, "")));
         });
         if (fileOnly) {

--- a/example/This is a Markdown Test Blog.md
+++ b/example/This is a Markdown Test Blog.md
@@ -1,0 +1,15 @@
+first paragraph with title.
+
+
+second paragraph.
+should be same as 2.
+
+third paragraph has a link to [Github](https://github.com/) in the middle of the paragraph!
+
+fourth paragraph has a link in the end of the paragraph [Github](https://github.com/)
+
+[Github](https://github.com/) fifth paragraph has a link to the beginning!
+
+[Github](https://github.com/) sixth paragraph has lots of [Github](https://github.com/) links within itself [Github](https://github.com/)
+
+[Github](https://github.com/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tilvert",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tilvert",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "bin": {
         "tilvert": "dist/src/main.js"
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/node": "^20.5.9",
         "gh-pages": "^6.0.0",
+        "prettier": "^3.0.3",
         "typescript": "^5.2.2"
       }
     },
@@ -421,6 +422,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Omar Hussein",
     "url": "https://github.com/omalk98"
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Markdown to HTML CLI converter",
   "main": "./dist/src/main.js",
   "bin": {

--- a/src/utils/process-file.ts
+++ b/src/utils/process-file.ts
@@ -49,6 +49,25 @@ export async function processFile(
   });
 
   segments.forEach((segment) => {
+    if (extension === "md") {
+      const markdownLinkRegex = /\[([^\]]+)\]\(([^\)]+)\)/g;
+      const markdownLinks = segment.match(markdownLinkRegex);
+
+      if (markdownLinks && markdownLinks.length > 0) {
+        markdownLinks.forEach((link) => {
+          const linkGroup = link.match(/\[([^\]]+)\]\(([^\)]+)\)/);
+
+          if (linkGroup) {
+            const anchorTag = TILvertHTMLDocument.createTag("a", linkGroup[1], {
+              href: linkGroup[2],
+              target: "_blank",
+            });
+            segment = segment.replace(linkGroup[0], anchorTag);
+          }
+        });
+      }
+    }
+
     htmlDoc.appendToBody(
       TILvertHTMLDocument.createTag("p", segment.replace(/\n|\r/, ""))
     );


### PR DESCRIPTION
Initial MD link support has been added and thoroughly tested. Please take a look at the code and provide feedback accordingly.

* Fixes issue #7  

<ins>*Result:*<ins/>
<img width="456" alt="image" src="https://github.com/omalk98/TILvert/assets/71615163/fb7da92c-3a37-4649-9393-8ea98ff937f6">

<ins>*MD file used to test & generate HTML:*<ins/>
![image](https://github.com/omalk98/TILvert/assets/71615163/c4cf9a0d-fd62-465a-9388-35eac4e045e8)

<ins>*Changes:*<ins/>
- Checks to see if the extension of the file is `.md`, if it is only then run the logic to generate `<a>` tags
- Finds all the links from each paragraph and iterates over it to convert each link to an `<a>` tag
- Uses a robust regular expression to match the pattern and find the links
- Utilizes existing function viz., `createTag()` to generate `<a>` tags
- Generates the anchor tag before converting the text to a `<p>` tag to make sure parsing every link is taken care of.

<ins>*Fixes needed in other parts of code:*<ins/>

The md feature currently only works when we explicitly pass a `-e md` flag which was the default functionality. Otherwise, it won't detect when a md file or a dir containing md file is passed to the tool. I believe we'd want to parse either txt or md file so need to get rid of the constraint of explicitly passing an extension flag to convert markdown files. Fix to this issue has not been made a part of this PR since this PR focuses explicitly on adding a markdown feature, viz., parsing links to HTML-supported `<a>` tags. 